### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This lets Claude remember information about the user across chats.
 > [!NOTE]
 > This is a fork of the original [Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) and is intended to not use the ephemeral memory npx installation method.
 
+<a href="https://glama.ai/mcp/servers/zn6gf7sxjs"><img width="380" height="200" src="https://glama.ai/mcp/servers/zn6gf7sxjs/badge" alt="mcp-knowledge-graph MCP server" /></a>
+
 ## Server Name
 
 ```txt


### PR DESCRIPTION
This PR adds a badge for the mcp-knowledge-graph server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zn6gf7sxjs"><img width="380" height="200" src="https://glama.ai/mcp/servers/zn6gf7sxjs/badge" alt="mcp-knowledge-graph MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.