### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Knowledge Graph Memory Server
+[![smithery badge](https://smithery.ai/badge/mcp-knowledge-graph)](https://smithery.ai/server/mcp-knowledge-graph)
 
 An improved implementation of persistent memory using a local knowledge graph with a customizable `--memory-path`.
 


### PR DESCRIPTION
This PR makes the following update to the README:

1. Adds a badge showing the number of installations for the Knowledge Graph Memory Server from Smithery: https://smithery.ai/server/mcp-knowledge-graph. This provides visibility into the server's adoption and encourages transparency.

Let me know if any further modifications are required!